### PR TITLE
Fix forever highlighted radical and square buttons

### DIFF
--- a/mathEditor/editor/MTEditableMathLabel.m
+++ b/mathEditor/editor/MTEditableMathLabel.m
@@ -363,6 +363,9 @@
 - (void) setKeyboardMode
 {
     self.keyboard.exponentHighlighted = NO;
+    self.keyboard.radicalHighlighted = NO;
+    self.keyboard.squareRootHighlighted = NO;
+
     if ([_insertionIndex hasSubIndexOfType:kMTSubIndexTypeSuperscript]) {
         self.keyboard.exponentHighlighted = YES;
         self.keyboard.equalsAllowed = NO;


### PR DESCRIPTION
Once highlighted radical and square buttons were staying
in the highlighted state forever.